### PR TITLE
Fix dataset file names to match methname files

### DIFF
--- a/pytorch/configs.py
+++ b/pytorch/configs.py
@@ -4,18 +4,18 @@ def config_JointEmbeder():
         # data_params
         'dataset_name':'CodeSearchDataset', # name of dataset to specify a data loader
             #training data
-            'train_name':'train.name.h5',
+            'train_name':'train.methname.h5',
             'train_api':'train.apiseq.h5',
             'train_tokens':'train.tokens.h5',
             'train_desc':'train.desc.h5',
             #test data
-            'valid_name':'valid.name.h5',
+            'valid_name':'valid.methname.h5',
             'valid_api':'valid.apiseq.h5',
             'valid_tokens':'valid.tokens.h5',
             'valid_desc':'valid.desc.h5',
             #use data (computing code vectors)
             'use_codebase':'use.rawcode.txt',#'use.rawcode.h5'
-            'use_names':'use.name.h5',
+            'use_names':'use.methname.h5',
             'use_apis':'use.apiseq.h5',
             'use_tokens':'use.tokens.h5',     
             #results data(code vectors)            

--- a/pytorch/data_loader.py
+++ b/pytorch/data_loader.py
@@ -113,11 +113,11 @@ def save_vecs(vecs, fout):
 
 if __name__ == '__main__':
     input_dir='./data/github/'
-    train_set=CodeSearchDataset(input_dir, 'train.name.h5', 6, 'train.apiseq.h5', 20, 'train.tokens.h5', 30, 'train.desc.h5', 30)
+    train_set=CodeSearchDataset(input_dir, 'train.methname.h5', 6, 'train.apiseq.h5', 20, 'train.tokens.h5', 30, 'train.desc.h5', 30)
     train_data_loader=torch.utils.data.DataLoader(dataset=train_set, batch_size=1, shuffle=False, num_workers=1)
-    valid_set=CodeSearchDataset(input_dir, 'valid.name.h5', 6, 'valid.apiseq.h5', 20, 'valid.tokens.h5', 30, 'valid.desc.h5', 30)
+    valid_set=CodeSearchDataset(input_dir, 'valid.methname.h5', 6, 'valid.apiseq.h5', 20, 'valid.tokens.h5', 30, 'valid.desc.h5', 30)
     valid_data_loader=torch.utils.data.DataLoader(dataset=valid_set, batch_size=1, shuffle=False, num_workers=1)
-    use_set=CodeSearchDataset(input_dir, 'use.name.h5', 6, 'use.apiseq.h5', 20, 'use.tokens.h5', 30)
+    use_set=CodeSearchDataset(input_dir, 'use.methname.h5', 6, 'use.apiseq.h5', 20, 'use.tokens.h5', 30)
     use_data_loader=torch.utils.data.DataLoader(dataset=use_set, batch_size=1, shuffle=False, num_workers=1)
     vocab_api = load_dict(input_dir+'vocab.apiseq.json')
     vocab_name = load_dict(input_dir+'vocab.name.json')


### PR DESCRIPTION
## Summary
- update the JointEmbeder configuration to reference the methname-based dataset files that exist in the repository
- align the standalone data loader script with the methname file names

## Testing
- python -m compileall pytorch

------
https://chatgpt.com/codex/tasks/task_e_68c8dd58e8708323ae08a9375e5d5909